### PR TITLE
add new memory-counter to check memory-allocations for memory-leak-tests

### DIFF
--- a/include/libKitsunemimiCommon/buffer/data_buffer.h
+++ b/include/libKitsunemimiCommon/buffer/data_buffer.h
@@ -22,8 +22,11 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#include <libKitsunemimiCommon/memory_counter.h>
+
 namespace Kitsunemimi
 {
+
 struct DataBuffer;
 inline bool allocateBlocks_DataBuffer(DataBuffer &buffer, const uint64_t numberOfBlocks);
 inline bool addData_DataBuffer(DataBuffer &buffer, const void* data, const uint64_t dataSize);
@@ -180,6 +183,9 @@ alignedMalloc(const uint16_t blockSize,
         return nullptr;
     }
 
+    const size_t memSize = *((size_t*)ptr - 1);
+    Kitsunemimi::increaseGlobalMemoryCounter(memSize);
+
     // init memory
     memset(ptr, 0, numberOfBytes);
 
@@ -201,6 +207,9 @@ alignedFree(void* ptr)
     if(ptr == nullptr) {
         return false;
     }
+
+    const size_t memSize = *((size_t*)ptr - 1);
+    Kitsunemimi::decreaseGlobalMemoryCounter(memSize);
 
     // free data
     free(ptr);

--- a/include/libKitsunemimiCommon/memory_counter.h
+++ b/include/libKitsunemimiCommon/memory_counter.h
@@ -1,0 +1,44 @@
+/**
+ *  @file       memory_counter.h
+ *
+ *  @brief      Counter for allocated and freed bytes to identify memory-leaks
+ *
+ *  @author     Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ *  @copyright  MIT License
+ */
+
+#ifndef MEMORY_COUNTER_H
+#define MEMORY_COUNTER_H
+
+#include <stdlib.h>
+#include <atomic>
+#include <stdio.h>
+
+void* operator new(size_t size);
+void* operator new[](size_t size);
+void  operator delete(void* ptr);
+void  operator delete[](void* ptr);
+
+
+namespace Kitsunemimi
+{
+
+struct MemoryCounter
+{
+    int64_t actualAllocatedSize = 0;
+    std::atomic_flag lock = ATOMIC_FLAG_INIT;
+    uint8_t padding[7];
+
+    static Kitsunemimi::MemoryCounter* globalMemoryCounter;
+
+    MemoryCounter() {}
+};
+
+
+void increaseGlobalMemoryCounter(const size_t size);
+void decreaseGlobalMemoryCounter(const size_t size);
+
+}
+
+#endif // MEMORY_COUNTER_H

--- a/include/libKitsunemimiCommon/memory_counter.h
+++ b/include/libKitsunemimiCommon/memory_counter.h
@@ -30,7 +30,7 @@ struct MemoryCounter
     std::atomic_flag lock = ATOMIC_FLAG_INIT;
     uint8_t padding[7];
 
-    static Kitsunemimi::MemoryCounter* globalMemoryCounter;
+    static Kitsunemimi::MemoryCounter globalMemoryCounter;
 
     MemoryCounter() {}
 };

--- a/src/memory_counter.cpp
+++ b/src/memory_counter.cpp
@@ -1,0 +1,95 @@
+/**
+ *  @file       memory_counter.cpp
+ *
+ *  @brief      Counter for allocated and freed bytes to identify memory-leaks
+ *
+ *  @author     Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ *  @copyright  MIT License
+ */
+
+#include <libKitsunemimiCommon/memory_counter.h>
+
+#include <stdio.h>
+
+Kitsunemimi::MemoryCounter* Kitsunemimi::MemoryCounter::globalMemoryCounter = nullptr;
+
+void*
+operator new(size_t size)
+{
+    void* ptr = malloc(size);
+    const size_t memSize = *((size_t*)ptr - 1);
+    Kitsunemimi::increaseGlobalMemoryCounter(memSize);
+    return ptr;
+}
+
+void*
+operator new[](size_t size)
+{
+    void* ptr = malloc(size);
+    const size_t memSize = *((size_t*)ptr - 1);
+    Kitsunemimi::increaseGlobalMemoryCounter(memSize);
+    return ptr;
+}
+
+void
+operator delete(void* ptr)
+{
+    const size_t memSize = *((size_t*)ptr - 1);
+    Kitsunemimi::decreaseGlobalMemoryCounter(memSize);
+    free(ptr);
+}
+
+void
+operator delete[](void* ptr)
+{
+    const size_t memSize = *((size_t*)ptr - 1);
+    Kitsunemimi::decreaseGlobalMemoryCounter(memSize);
+    free(ptr);
+}
+
+
+namespace Kitsunemimi
+{
+
+    /**
+ * @brief increaseGlobalMemoryCounter
+ * @param size
+ */
+void
+increaseGlobalMemoryCounter(size_t size)
+{
+    if(MemoryCounter::globalMemoryCounter == nullptr)
+    {
+        MemoryCounter::globalMemoryCounter =
+                static_cast<MemoryCounter*>(malloc(sizeof(MemoryCounter)));
+    }
+
+    while(MemoryCounter::globalMemoryCounter->lock.test_and_set(std::memory_order_acquire)) {
+        asm("");
+    }
+    Kitsunemimi::MemoryCounter::globalMemoryCounter->actualAllocatedSize += size;
+    Kitsunemimi::MemoryCounter::globalMemoryCounter->lock.clear(std::memory_order_release);
+}
+
+/**
+ * @brief decreaseGlobalMemoryCounter
+ * @param size
+ */
+void
+decreaseGlobalMemoryCounter(size_t size)
+{
+    if(MemoryCounter::globalMemoryCounter == nullptr)
+    {
+        MemoryCounter::globalMemoryCounter =
+                static_cast<MemoryCounter*>(malloc(sizeof(MemoryCounter)));
+    }
+
+    while(MemoryCounter::globalMemoryCounter->lock.test_and_set(std::memory_order_acquire)) {
+        asm("");
+    }
+    MemoryCounter::globalMemoryCounter->actualAllocatedSize -= size;
+    MemoryCounter::globalMemoryCounter->lock.clear(std::memory_order_release);
+}
+
+}

--- a/src/src.pro
+++ b/src/src.pro
@@ -19,7 +19,8 @@ SOURCES += \
     test_helper/speed_test_helper.cpp \
     buffer/stack_buffer_reserve.cpp \
     common_methods/string_methods.cpp \
-    common_methods/vector_methods.cpp
+    common_methods/vector_methods.cpp \
+    memory_counter.cpp
 
 
 HEADERS += \
@@ -37,4 +38,5 @@ HEADERS += \
     ../include/libKitsunemimiCommon/test_helper/speed_test_helper.h \
     ../include/libKitsunemimiCommon/buffer/data_buffer.h \
     ../include/libKitsunemimiCommon/buffer/stack_buffer.h \
-    ../include/libKitsunemimiCommon/buffer/stack_buffer_reserve.h
+    ../include/libKitsunemimiCommon/buffer/stack_buffer_reserve.h \
+    ../include/libKitsunemimiCommon/memory_counter.h


### PR DESCRIPTION
## Description

- add new memory-counter to check memory-allocations for memory-leak-tests

## Related Issues

- close #91 

## How it was tested?

simple tool:

```
#include <memory>
#include <iostream>
#include <string.h>

#include <libKitsunemimiCommon/buffer/data_buffer.h>
#include <libKitsunemimiCommon/common_items/data_items.h>

using namespace Kitsunemimi;

int main()
{
    DataBuffer* buffer1 = new DataBuffer();
    std::cout<<Kitsunemimi::MemoryCounter::globalMemoryCounter->actualAllocatedSize<<std::endl;
    DataBuffer buffer2;
    std::cout<<Kitsunemimi::MemoryCounter::globalMemoryCounter->actualAllocatedSize<<std::endl;
    delete buffer1;
    std::cout<<Kitsunemimi::MemoryCounter::globalMemoryCounter->actualAllocatedSize<<std::endl;
    buffer2.clear();
    std::cout<<Kitsunemimi::MemoryCounter::globalMemoryCounter->actualAllocatedSize<<std::endl;

    DataMap* map = new DataMap();
    std::cout<<Kitsunemimi::MemoryCounter::globalMemoryCounter->actualAllocatedSize<<std::endl;
    map->insert("test1" , new DataValue(1234));
    std::cout<<Kitsunemimi::MemoryCounter::globalMemoryCounter->actualAllocatedSize<<std::endl;
    map->insert("test2" , new DataValue("asdfasdfasdfs"));
    std::cout<<Kitsunemimi::MemoryCounter::globalMemoryCounter->actualAllocatedSize<<std::endl;
    delete map;
    std::cout<<Kitsunemimi::MemoryCounter::globalMemoryCounter->actualAllocatedSize<<std::endl;
}
```
