### PR TITLE
Reset memory counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,6 @@ Memory-leak detected
    File: "<file-path where thre failed test is located>"
    Method: "<method name where thre failed test is located>"
    Line: "<line-number of the failed test inside the test-class>"
-   Leaked Bytes: "<number of leaked bytes>"
    Number of missing deallocations: "<number of deallocations, which are missing>"
 ```
 

--- a/include/libKitsunemimiCommon/test_helper/memory_leak_test_helper.h
+++ b/include/libKitsunemimiCommon/test_helper/memory_leak_test_helper.h
@@ -24,12 +24,10 @@ class MemoryLeakTestHelpter
 {
 #define REINIT_TEST() \
     m_currentAllocations = MemoryCounter::globalMemoryCounter.numberOfActiveAllocations; \
-    m_currentSize = MemoryCounter::globalMemoryCounter.actualAllocatedSize;
 
 #define CHECK_MEMORY() \
     if(MemoryCounter::globalMemoryCounter.numberOfActiveAllocations - m_currentAllocations != 0) \
     {  \
-        int64_t nbytes = MemoryCounter::globalMemoryCounter.actualAllocatedSize - m_currentSize; \
         int64_t ndiff = MemoryCounter::globalMemoryCounter.numberOfActiveAllocations \
                         - m_currentAllocations; \
         std::cout << std::endl; \
@@ -37,7 +35,6 @@ class MemoryLeakTestHelpter
         std::cout << "   File: " << __FILE__ << std::endl; \
         std::cout << "   Method: " << __PRETTY_FUNCTION__ << std::endl; \
         std::cout << "   Line: " << __LINE__ << std::endl; \
-        std::cout << "   Leaked Bytes: " << (nbytes) << std::endl; \
         std::cout << "   Number of missing deallocations: " << (ndiff) << std::endl; \
         std::cout << std::endl; \
         m_failedTests++; \
@@ -52,7 +49,6 @@ public:
     ~MemoryLeakTestHelpter();
 
 protected:
-    int64_t m_currentSize = 0;
     int64_t m_currentAllocations = 0;
 
     uint32_t m_failedTests = 0;

--- a/src/memory_counter.cpp
+++ b/src/memory_counter.cpp
@@ -28,37 +28,31 @@ Kitsunemimi::MemoryCounter Kitsunemimi::MemoryCounter::globalMemoryCounter;
 void*
 operator new(size_t size)
 {
-    void* ptr = malloc(sizeof(size_t) + size);
-    *((size_t*)ptr) = size;
-    Kitsunemimi::increaseGlobalMemoryCounter(size);
-    return (void*) ((size_t *)ptr + 1);
+    void* ptr = malloc(size);
+    Kitsunemimi::increaseGlobalMemoryCounter(0);
+    return ptr;
 }
 
 void*
 operator new[](size_t size)
 {
-    void* ptr = malloc(sizeof(size_t) + size);
-    *((size_t*)ptr) = size;
-    Kitsunemimi::increaseGlobalMemoryCounter(size);
-    return (void*) ((size_t *)ptr + 1);
+    void* ptr = malloc(size);
+    Kitsunemimi::increaseGlobalMemoryCounter(0);
+    return ptr;
 }
 
 void
 operator delete(void* ptr)
 {
-    ptr = (size_t*)ptr - 1;
-    const size_t size = *((size_t*)ptr);
-    Kitsunemimi::decreaseGlobalMemoryCounter(size);
     free(ptr);
+    Kitsunemimi::decreaseGlobalMemoryCounter(0);
 }
 
 void
 operator delete[](void* ptr)
 {
-    ptr = (size_t*)ptr - 1;
-    const size_t size = *((size_t*)ptr);
-    Kitsunemimi::decreaseGlobalMemoryCounter(size);
     free(ptr);
+    Kitsunemimi::decreaseGlobalMemoryCounter(0);
 }
 
 //==================================================================================================

--- a/src/test_helper/memory_leak_test_helper.cpp
+++ b/src/test_helper/memory_leak_test_helper.cpp
@@ -21,7 +21,6 @@ namespace Kitsunemimi
 MemoryLeakTestHelpter::MemoryLeakTestHelpter(const std::string &testName)
 {
     m_currentAllocations = MemoryCounter::globalMemoryCounter.numberOfActiveAllocations;
-    m_currentSize = MemoryCounter::globalMemoryCounter.actualAllocatedSize;
 
     std::cout << "------------------------------" << std::endl;
     std::cout << "start " << testName << std::endl << std::endl;


### PR DESCRIPTION
## Description

Memory-counter only counter number of allocations and only number of bytes from the data-buffer-class

## Related Issues

- #105 

## How it was tested?

- ci-pipeline